### PR TITLE
Location and Organization ID

### DIFF
--- a/foreman/api/architecture.go
+++ b/foreman/api/architecture.go
@@ -74,7 +74,7 @@ func (c *Client) CreateArchitecture(a *ForemanArchitecture) (*ForemanArchitectur
 
 	reqEndpoint := fmt.Sprintf("/%s", ArchitectureEndpointPrefix)
 
-	archJSONBytes, jsonEncErr := WrapJson("architecture", a)
+	archJSONBytes, jsonEncErr := c.WrapJSON("architecture", a)
 	if jsonEncErr != nil {
 		return nil, jsonEncErr
 	}
@@ -137,7 +137,7 @@ func (c *Client) UpdateArchitecture(a *ForemanArchitecture) (*ForemanArchitectur
 
 	reqEndpoint := fmt.Sprintf("/%s/%d", ArchitectureEndpointPrefix, a.Id)
 
-	archJSONBytes, jsonEncErr := WrapJson("architecture", a)
+	archJSONBytes, jsonEncErr := c.WrapJSON("architecture", a)
 	if jsonEncErr != nil {
 		return nil, jsonEncErr
 	}

--- a/foreman/api/common_parameter.go
+++ b/foreman/api/common_parameter.go
@@ -44,7 +44,7 @@ func (c *Client) CreateCommonParameter(d *ForemanCommonParameter) (*ForemanCommo
 
 	// All commonParameters are send individually. Yeay for that
 	var createdCommonParameter ForemanCommonParameter
-	commonParameterJSONBytes, jsonEncErr := WrapJson("common_parameter", d)
+	commonParameterJSONBytes, jsonEncErr := c.WrapJSON("common_parameter", d)
 	if jsonEncErr != nil {
 		return nil, jsonEncErr
 	}
@@ -109,7 +109,7 @@ func (c *Client) UpdateCommonParameter(d *ForemanCommonParameter, id int) (*Fore
 
 	reqEndpoint := fmt.Sprintf(CommonParameterEndpointPrefix+"/%d", id)
 
-	commonParameterJSONBytes, jsonEncErr := WrapJson("common_parameter", d)
+	commonParameterJSONBytes, jsonEncErr := c.WrapJSON("common_parameter", d)
 	if jsonEncErr != nil {
 		return nil, jsonEncErr
 	}

--- a/foreman/api/computeresource.go
+++ b/foreman/api/computeresource.go
@@ -113,7 +113,7 @@ func (c *Client) CreateComputeResource(d *ForemanComputeResource) (*ForemanCompu
 
 	reqEndpoint := fmt.Sprintf("/%s", ComputeResourceEndpointPrefix)
 
-	computeresourceJSONBytes, jsonEncErr := WrapJson("compute_resource", d)
+	computeresourceJSONBytes, jsonEncErr := c.WrapJSON("compute_resource", d)
 	if jsonEncErr != nil {
 		return nil, jsonEncErr
 	}
@@ -175,7 +175,7 @@ func (c *Client) UpdateComputeResource(d *ForemanComputeResource) (*ForemanCompu
 
 	reqEndpoint := fmt.Sprintf("/%s/%d", ComputeResourceEndpointPrefix, d.Id)
 
-	computeresourceJSONBytes, jsonEncErr := WrapJson("compute_resource", d)
+	computeresourceJSONBytes, jsonEncErr := c.WrapJSON("compute_resource", d)
 	if jsonEncErr != nil {
 		return nil, jsonEncErr
 	}

--- a/foreman/api/defaulttemplate.go
+++ b/foreman/api/defaulttemplate.go
@@ -43,7 +43,7 @@ func (c *Client) CreateDefaultTemplate(d *ForemanDefaultTemplate) (*ForemanDefau
 
 	// All parameters are send individually. Yeay for that
 	var createdDefaultTemplate ForemanDefaultTemplate
-	parameterJSONBytes, jsonEncErr := WrapJson("os_default_template", d)
+	parameterJSONBytes, jsonEncErr := c.WrapJSON("os_default_template", d)
 	if jsonEncErr != nil {
 		return nil, jsonEncErr
 	}
@@ -101,7 +101,7 @@ func (c *Client) UpdateDefaultTemplate(d *ForemanDefaultTemplate, id int) (*Fore
 	log.Tracef("foreman/api/parameter.go#Update")
 
 	reqEndpoint := fmt.Sprintf(DefaultTemplateEndpointPrefix+"/%d", d.OperatingSystemId, id)
-	parameterJSONBytes, jsonEncErr := WrapJson("os_default_template", d)
+	parameterJSONBytes, jsonEncErr := c.WrapJSON("os_default_template", d)
 	if jsonEncErr != nil {
 		return nil, jsonEncErr
 	}

--- a/foreman/api/domain.go
+++ b/foreman/api/domain.go
@@ -44,7 +44,7 @@ func (c *Client) CreateDomain(d *ForemanDomain) (*ForemanDomain, error) {
 
 	reqEndpoint := fmt.Sprintf("/%s", DomainEndpointPrefix)
 
-	domainJSONBytes, jsonEncErr := WrapJson("domain", d)
+	domainJSONBytes, jsonEncErr := c.WrapJSON("domain", d)
 	if jsonEncErr != nil {
 		return nil, jsonEncErr
 	}
@@ -106,7 +106,7 @@ func (c *Client) UpdateDomain(d *ForemanDomain, id int) (*ForemanDomain, error) 
 
 	reqEndpoint := fmt.Sprintf("/%s/%d", DomainEndpointPrefix, id)
 
-	domainJSONBytes, jsonEncErr := WrapJson("domain", d)
+	domainJSONBytes, jsonEncErr := c.WrapJSON("domain", d)
 	if jsonEncErr != nil {
 		return nil, jsonEncErr
 	}

--- a/foreman/api/environment.go
+++ b/foreman/api/environment.go
@@ -36,7 +36,7 @@ func (c *Client) CreateEnvironment(e *ForemanEnvironment) (*ForemanEnvironment, 
 
 	reqEndpoint := fmt.Sprintf("/%s", EnvironmentEndpointPrefix)
 
-	environmentJSONBytes, jsonEncErr := WrapJson("environment", e)
+	environmentJSONBytes, jsonEncErr := c.WrapJSON("environment", e)
 	if jsonEncErr != nil {
 		return nil, jsonEncErr
 	}
@@ -99,7 +99,7 @@ func (c *Client) UpdateEnvironment(e *ForemanEnvironment) (*ForemanEnvironment, 
 
 	reqEndpoint := fmt.Sprintf("/%s/%d", EnvironmentEndpointPrefix, e.Id)
 
-	environmentJSONBytes, jsonEncErr := WrapJson("environment", e)
+	environmentJSONBytes, jsonEncErr := c.WrapJSON("environment", e)
 	if jsonEncErr != nil {
 		return nil, jsonEncErr
 	}

--- a/foreman/api/host.go
+++ b/foreman/api/host.go
@@ -316,7 +316,7 @@ func (c *Client) CreateHost(h *ForemanHost, retryCount int) (*ForemanHost, error
 
 	reqEndpoint := fmt.Sprintf("/%s", HostEndpointPrefix)
 
-	hJSONBytes, jsonEncErr := WrapJson("host", h)
+	hJSONBytes, jsonEncErr := c.WrapJSON("host", h)
 	if jsonEncErr != nil {
 		return nil, jsonEncErr
 	}
@@ -395,7 +395,7 @@ func (c *Client) UpdateHost(h *ForemanHost, retryCount int) (*ForemanHost, error
 	// Cannot update interfaces in-place. And causes errors if the object is set
 	h.InterfacesAttributes = nil
 
-	hJSONBytes, jsonEncErr := WrapJson("host", h)
+	hJSONBytes, jsonEncErr := c.WrapJSON("host", h)
 	if jsonEncErr != nil {
 		return nil, jsonEncErr
 	}

--- a/foreman/api/hostgroup.go
+++ b/foreman/api/hostgroup.go
@@ -162,7 +162,7 @@ func (c *Client) CreateHostgroup(h *ForemanHostgroup) (*ForemanHostgroup, error)
 
 	reqEndpoint := fmt.Sprintf("/%s", HostgroupEndpointPrefix)
 
-	hJSONBytes, jsonEncErr := WrapJson("hostgroup", h)
+	hJSONBytes, jsonEncErr := c.WrapJSON("hostgroup", h)
 	if jsonEncErr != nil {
 		return nil, jsonEncErr
 	}
@@ -225,7 +225,7 @@ func (c *Client) UpdateHostgroup(h *ForemanHostgroup) (*ForemanHostgroup, error)
 
 	reqEndpoint := fmt.Sprintf("/%s/%d", HostgroupEndpointPrefix, h.Id)
 
-	hJSONBytes, jsonEncErr := WrapJson("hostgroup", h)
+	hJSONBytes, jsonEncErr := c.WrapJSON("hostgroup", h)
 	if jsonEncErr != nil {
 		return nil, jsonEncErr
 	}

--- a/foreman/api/image.go
+++ b/foreman/api/image.go
@@ -99,7 +99,7 @@ func (c *Client) CreateImage(d *ForemanImage, compute_resource int) (*ForemanIma
 
 	reqEndpoint := fmt.Sprintf("%s/%d/images", ComputeResourceEndpoint, compute_resource)
 
-	imageJSONBytes, jsonEncErr := WrapJson("image", d)
+	imageJSONBytes, jsonEncErr := c.WrapJSON("image", d)
 	if jsonEncErr != nil {
 		return nil, jsonEncErr
 	}
@@ -161,7 +161,7 @@ func (c *Client) UpdateImage(d *ForemanImage) (*ForemanImage, error) {
 
 	reqEndpoint := fmt.Sprintf("/%s/%d/images/%d", ComputeResourceEndpoint, d.ComputeResourceID, d.Id)
 
-	imageJSONBytes, jsonEncErr := WrapJson("image", d)
+	imageJSONBytes, jsonEncErr := c.WrapJSON("image", d)
 	if jsonEncErr != nil {
 		return nil, jsonEncErr
 	}

--- a/foreman/api/media.go
+++ b/foreman/api/media.go
@@ -100,7 +100,7 @@ func (c *Client) CreateMedia(m *ForemanMedia) (*ForemanMedia, error) {
 
 	reqEndpoint := fmt.Sprintf("/%s", MediaEndpointPrefix)
 
-	mJSONBytes, jsonEncErr := WrapJson("medium", m)
+	mJSONBytes, jsonEncErr := c.WrapJSON("medium", m)
 	if jsonEncErr != nil {
 		return nil, jsonEncErr
 	}
@@ -162,7 +162,7 @@ func (c *Client) UpdateMedia(m *ForemanMedia) (*ForemanMedia, error) {
 
 	reqEndpoint := fmt.Sprintf("/%s/%d", MediaEndpointPrefix, m.Id)
 
-	mJSONBytes, jsonEncErr := WrapJson("medium", m)
+	mJSONBytes, jsonEncErr := c.WrapJSON("medium", m)
 	if jsonEncErr != nil {
 		return nil, jsonEncErr
 	}

--- a/foreman/api/model.go
+++ b/foreman/api/model.go
@@ -43,7 +43,7 @@ func (c *Client) CreateModel(m *ForemanModel) (*ForemanModel, error) {
 
 	reqEndpoint := fmt.Sprintf("/%s", ModelEndpointPrefix)
 
-	mJSONBytes, jsonEncErr := WrapJson("model", m)
+	mJSONBytes, jsonEncErr := c.WrapJSON("model", m)
 	if jsonEncErr != nil {
 		return nil, jsonEncErr
 	}
@@ -105,7 +105,7 @@ func (c *Client) UpdateModel(m *ForemanModel) (*ForemanModel, error) {
 
 	reqEndpoint := fmt.Sprintf("/%s/%d", ModelEndpointPrefix, m.Id)
 
-	mJSONBytes, jsonEncErr := WrapJson("model", m)
+	mJSONBytes, jsonEncErr := c.WrapJSON("model", m)
 	if jsonEncErr != nil {
 		return nil, jsonEncErr
 	}

--- a/foreman/api/operatingsystem.go
+++ b/foreman/api/operatingsystem.go
@@ -135,7 +135,7 @@ func (c *Client) CreateOperatingSystem(o *ForemanOperatingSystem) (*ForemanOpera
 
 	reqEndpoint := fmt.Sprintf("/%s", OperatingSystemEndpointPrefix)
 
-	osJSONBytes, jsonEncErr := WrapJson("operatingsystem", o)
+	osJSONBytes, jsonEncErr := c.WrapJSON("operatingsystem", o)
 	if jsonEncErr != nil {
 		return nil, jsonEncErr
 	}
@@ -199,7 +199,7 @@ func (c *Client) UpdateOperatingSystem(o *ForemanOperatingSystem) (*ForemanOpera
 
 	reqEndpoint := fmt.Sprintf("/%s/%d", OperatingSystemEndpointPrefix, o.Id)
 
-	osJSONBytes, jsonEncErr := WrapJson("operatingsystem", o)
+	osJSONBytes, jsonEncErr := c.WrapJSON("operatingsystem", o)
 	if jsonEncErr != nil {
 		return nil, jsonEncErr
 	}

--- a/foreman/api/partitiontable.go
+++ b/foreman/api/partitiontable.go
@@ -115,7 +115,7 @@ func (c *Client) CreatePartitionTable(t *ForemanPartitionTable) (*ForemanPartiti
 
 	reqEndpoint := fmt.Sprintf("/%s", PartitionTableEndpointPrefix)
 
-	tJSONBytes, jsonEncErr := WrapJson("ptable", t)
+	tJSONBytes, jsonEncErr := c.WrapJSON("ptable", t)
 	if jsonEncErr != nil {
 		return nil, jsonEncErr
 	}
@@ -178,7 +178,7 @@ func (c *Client) UpdatePartitionTable(t *ForemanPartitionTable) (*ForemanPartiti
 
 	reqEndpoint := fmt.Sprintf("/%s/%d", PartitionTableEndpointPrefix, t.Id)
 
-	tJSONBytes, jsonEncErr := WrapJson("ptable", t)
+	tJSONBytes, jsonEncErr := c.WrapJSON("ptable", t)
 	if jsonEncErr != nil {
 		return nil, jsonEncErr
 	}

--- a/foreman/api/provisioningtemplate.go
+++ b/foreman/api/provisioningtemplate.go
@@ -191,7 +191,7 @@ func (c *Client) CreateProvisioningTemplate(t *ForemanProvisioningTemplate) (*Fo
 
 	reqEndpoint := fmt.Sprintf("/%s", ProvisioningTemplateEndpointPrefix)
 
-	tJSONBytes, jsonEncErr := WrapJson("provisioning_template", t)
+	tJSONBytes, jsonEncErr := c.WrapJSON("provisioning_template", t)
 	if jsonEncErr != nil {
 		return nil, jsonEncErr
 	}
@@ -255,7 +255,7 @@ func (c *Client) UpdateProvisioningTemplate(t *ForemanProvisioningTemplate) (*Fo
 	log.Tracef("foreman/api/provisioningtemplate.go#Update")
 
 	reqEndpoint := fmt.Sprintf("/%s/%d", ProvisioningTemplateEndpointPrefix, t.Id)
-	tJSONBytes, jsonEncErr := WrapJson("provisioning_template", t)
+	tJSONBytes, jsonEncErr := c.WrapJSON("provisioning_template", t)
 	if jsonEncErr != nil {
 		return nil, jsonEncErr
 	}

--- a/foreman/api/smartproxy.go
+++ b/foreman/api/smartproxy.go
@@ -48,7 +48,7 @@ func (c *Client) CreateSmartProxy(s *ForemanSmartProxy) (*ForemanSmartProxy, err
 
 	reqEndpoint := fmt.Sprintf("/%s", SmartProxyEndpointPrefix)
 
-	sJSONBytes, jsonEncErr := WrapJson("smart_proxy", s)
+	sJSONBytes, jsonEncErr := c.WrapJSON("smart_proxy", s)
 	if jsonEncErr != nil {
 		return nil, jsonEncErr
 	}
@@ -111,7 +111,7 @@ func (c *Client) UpdateSmartProxy(s *ForemanSmartProxy) (*ForemanSmartProxy, err
 
 	reqEndpoint := fmt.Sprintf("/%s/%d", SmartProxyEndpointPrefix, s.Id)
 
-	sJSONBytes, jsonEncErr := WrapJson("smart_proxy", s)
+	sJSONBytes, jsonEncErr := c.WrapJSON("smart_proxy", s)
 	if jsonEncErr != nil {
 		return nil, jsonEncErr
 	}

--- a/foreman/api/subnet.go
+++ b/foreman/api/subnet.go
@@ -60,7 +60,7 @@ func (c *Client) CreateSubnet(s *ForemanSubnet) (*ForemanSubnet, error) {
 
 	reqEndpoint := fmt.Sprintf("/%s", SubnetEndpointPrefix)
 
-	sJSONBytes, jsonEncErr := WrapJson("subnet", s)
+	sJSONBytes, jsonEncErr := c.WrapJSON("subnet", s)
 	if jsonEncErr != nil {
 		return nil, jsonEncErr
 	}
@@ -122,7 +122,7 @@ func (c *Client) UpdateSubnet(s *ForemanSubnet) (*ForemanSubnet, error) {
 
 	reqEndpoint := fmt.Sprintf("/%s/%d", SubnetEndpointPrefix, s.Id)
 
-	sJSONBytes, jsonEncErr := WrapJson("subnet", s)
+	sJSONBytes, jsonEncErr := c.WrapJSON("subnet", s)
 	if jsonEncErr != nil {
 		return nil, jsonEncErr
 	}

--- a/foreman/config.go
+++ b/foreman/config.go
@@ -19,6 +19,10 @@ type Config struct {
 	ClientTLSInsecure bool
 	// Set of credentials needed to authenticate against Foreman
 	ClientCredentials api.ClientCredentials
+	// Location for all API Calls
+	LocationID int
+	// Organization for all API Calls
+	OrganizationID int
 }
 
 // Client creates a client reference for the Foreman REST API given the
@@ -33,6 +37,8 @@ func (c *Config) Client() (*api.Client, error) {
 		c.ClientCredentials,
 		api.ClientConfig{
 			TLSInsecureEnabled: c.ClientTLSInsecure,
+			LocationID:         c.LocationID,
+			OrganizationID:     c.OrganizationID,
 		},
 	)
 

--- a/foreman/provider.go
+++ b/foreman/provider.go
@@ -146,6 +146,22 @@ func Provider() terraform.ResourceProvider {
 					"also be set through the environment variable `FOREMAN_CLIENT_PASSWORD`. " +
 					"Defaults to `\"\"`.",
 			},
+
+			// -- provider organization and location --
+			"organization_id": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  0,
+				Description: "The organization for all resource requsted and created by the Provier " +
+					"Defaults to \"0\"",
+			},
+			"location_id": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  0,
+				Description: "The location for all resources requested and created by the provider" +
+					"Defaults to \"0\"",
+			},
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
@@ -262,6 +278,8 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 			Username: d.Get("client_username").(string),
 			Password: d.Get("client_password").(string),
 		},
+		LocationID:     d.Get("location_id").(int),
+		OrganizationID: d.Get("organization_id").(int),
 	}
 
 	return config.Client()


### PR DESCRIPTION
Add support for Location and Organization IDs on all API calls (Closes: #3, Closes: #7)

This adds two optional arguments to the provider. `organization_id` and `location_id`. Both were optional until Foreman 1.21 but are since required. This change should not break any backwards compatibility but allow the provider to work with all Foreman versions 1.21 and newer as well. The extra arguments will default to the `Default Organization` and `Default Location` if not otherwise set. This should be the default behavior of Foreman prior to 1.21 as well.

I am still going to test this in our environment so I am keeping this as Draft until then.