### PR TITLE
Bugfix for subnet vlanid

### DIFF
--- a/foreman/api/subnet.go
+++ b/foreman/api/subnet.go
@@ -46,7 +46,7 @@ type ForemanSubnet struct {
 	// Network CIDR
 	NetworkAddress string `json:"network_address"`
 	// VLAN id that is in use in the subnet
-	VlanID int `json:"vlan_id"`
+	VlanID interface{} `json:"vlanid"`
 	// Description for the subnet
 	Description string `json:"description"`
 	// MTU Default for the subnet

--- a/foreman/resource_foreman_subnet.go
+++ b/foreman/resource_foreman_subnet.go
@@ -134,8 +134,8 @@ func resourceForemanSubnet() *schema.Resource {
 				Optional:    true,
 				Description: "The Subnets CIDR in the format 169.254.0.0/16",
 			},
-			"vlan_id": &schema.Schema{
-				Type:        schema.TypeInt,
+			"vlanid": &schema.Schema{
+				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "VLAN id that is in use in the subnet",
 			},
@@ -222,8 +222,8 @@ func buildForemanSubnet(d *schema.ResourceData) *api.ForemanSubnet {
 	if attr, ok = d.GetOk("network_address"); ok {
 		s.NetworkAddress = attr.(string)
 	}
-	if attr, ok = d.GetOk("vlan_id"); ok {
-		s.VlanID = attr.(int)
+	if attr, ok = d.GetOk("vlanid"); ok {
+		s.VlanID = attr.(string)
 	}
 	if attr, ok = d.GetOk("mtu"); ok {
 		s.Mtu = attr.(int)
@@ -264,7 +264,7 @@ func setResourceDataFromForemanSubnet(d *schema.ResourceData, fs *api.ForemanSub
 	d.Set("to", fs.To)
 	d.Set("boot_mode", fs.BootMode)
 	d.Set("network_address", fs.NetworkAddress)
-	d.Set("vlan_id", fs.VlanID)
+	d.Set("vlanid", fmt.Sprintf("%.0f", fs.VlanID))
 	d.Set("mtu", fs.Mtu)
 	d.Set("template_id", fs.TemplateID)
 	d.Set("dhcp_id", fs.DhcpID)


### PR DESCRIPTION
This PR addresses two problems:
* 'vlanid' is used instead of 'vlan_id
* the API requires a string as 'vlanid', but returns a number