### PR TITLE
Change URL regex to allow for valid FQDN

### DIFF
--- a/foreman/resource_foreman_smartproxy.go
+++ b/foreman/resource_foreman_smartproxy.go
@@ -19,13 +19,13 @@ const (
 	//
 	// 1. Starts with http or https followed by '://'
 	//   => http(s)?://
-	// 2. A number of repeating alpha-numeric character blocks seperated by a period
+	// 2. A number of repeating alpha-numeric and dash character blocks seperated by a period
 	//   => ([[:alnum:]]+\.)*
 	// 3. The last alpha-numeric block should not end with a period
 	//   => [[:alnum:]]+
 	// 4. Optionally end with a colon and the port
 	//   => (:[[:digit:]]{1,5})?
-	smartProxyURLRegex = `^http(s)?://([[:alnum:]]+\.)*[[:alnum:]]+(:[[:digit:]]{1,5})?$`
+	smartProxyURLRegex = `^http(s)?://([[:alnum:]|-]+\.)*[[:alnum:]|-]+(:[[:digit:]]{1,5})?$`
 )
 
 func resourceForemanSmartProxy() *schema.Resource {


### PR DESCRIPTION
Hi, thank you for all your work.

The current regex is a bit too strict, for example "https://foreman-smartproxy-1.our.domain.com" should be correct.
However the current regex only allows for alpha numeric characters. the proposed change would only add dashes.

However making a RFC compliant regex is non trivial, below mentioned packages could offload that responsibility.
net/url .pase() could also be used
asaskevich/govalidator .isURL() is also another option