### PR TITLE
Improve handling interfaces

### DIFF
--- a/foreman/api/host.go
+++ b/foreman/api/host.go
@@ -419,9 +419,6 @@ func (c *Client) UpdateHost(h *ForemanHost, retryCount int) (*ForemanHost, error
 
 	reqEndpoint := fmt.Sprintf("/%s/%d", HostEndpointPrefix, h.Id)
 
-	// Cannot update interfaces in-place. And causes errors if the object is set
-	h.InterfacesAttributes = nil
-
 	hJSONBytes, jsonEncErr := c.WrapJSONWithTaxonomy("host", h)
 	if jsonEncErr != nil {
 		return nil, jsonEncErr
@@ -504,8 +501,7 @@ func (c *Client) readComputeAttributes(id int) (map[string]interface{}, error) {
 	readVmAttributesStr := make(map[string]interface{}, len(readVmAttributes))
 
 	for idx, val := range readVmAttributes {
-		readVmAttributesStr[idx] = fmt.Sprint(val)
-		//readVmAttributesStr[idx], _ = json.Marshal(val)
+		readVmAttributesStr[idx] = val
 	}
 
 	return readVmAttributesStr, nil

--- a/foreman/resource_foreman_host.go
+++ b/foreman/resource_foreman_host.go
@@ -655,10 +655,13 @@ func setResourceDataFromForemanInterfacesAttributes(d *schema.ResourceData, fh *
 
 			"attached_devices": val.AttachedDevices,
 			"attached_to":      val.AttachedTo,
-
-			// NOTE(ALL): These settings only apply to virtual machines
-			"compute_attributes": interfaces_compute_attributes[val.MAC],
 		}
+
+		// NOTE(ALL): These settings only apply to virtual machines
+		if ifaceMap["compute_attributes"], ok = interfaces_compute_attributes[val.MAC]; !ok {
+			ifaceMap["compute_attributes"] = val.ComputeAttributes
+		}
+
 		ifaceArr[idx] = ifaceMap
 	}
 	// with the array set up, create the *schema.Set and set the ResourceData's


### PR DESCRIPTION
1. Switches interfaces to TypeList for proper updates;
2. Pulls compute attributes from the host, so that plan is clean (host compute attributes is the only place to fetch interface compute attributes);
3. Automatically fixes importing of interfaces;
4. Allows to send interface updates and removal - previously it was just disabled at the very last moment;

Fixes #31