### PR TITLE
Do not ForceNew on environment change and fix creation without environment

### DIFF
--- a/foreman/api/host.go
+++ b/foreman/api/host.go
@@ -169,7 +169,9 @@ func (fh ForemanHost) MarshalJSON() ([]byte, error) {
 	fhMap["model_id"] = intIdToJSONString(fh.ModelId)
 	fhMap["hostgroup_id"] = intIdToJSONString(fh.HostgroupId)
 	fhMap["owner_id"] = intIdToJSONString(fh.OwnerId)
-	fhMap["environment_id"] = intIdToJSONString(fh.EnvironmentId)
+	if fh.EnvironmentId > 0 {
+		fhMap["environment_id"] = intIdToJSONString(fh.EnvironmentId)
+	}
 	fhMap["compute_resource_id"] = intIdToJSONString(fh.ComputeResourceId)
 	fhMap["compute_profile_id"] = intIdToJSONString(fh.ComputeProfileId)
 	if len(fh.InterfacesAttributes) > 0 {

--- a/foreman/resource_foreman_host.go
+++ b/foreman/resource_foreman_host.go
@@ -144,7 +144,6 @@ func resourceForemanHost() *schema.Resource {
 			"environment_id": &schema.Schema{
 				Type:         schema.TypeInt,
 				Optional:     true,
-				ForceNew:     true,
 				Computed:     true,
 				ValidateFunc: validation.IntAtLeast(0),
 				Description:  "ID of the environment to assign to the host.",


### PR DESCRIPTION
1. It's totally possible to change the environment without destroying the host;
2. Foreman can take environment from hostgroup, so it's not needed to be specified. But the current code sends it in the payload as `nil`, which results in ` "error": {"id":null,"errors":{"environment_id":["can't be blank"]},"full_messages":["Environment can't be blank"]}`