### PR TITLE
Fix os default templates

### DIFF
--- a/foreman/api/defaulttemplate.go
+++ b/foreman/api/defaulttemplate.go
@@ -43,7 +43,8 @@ func (c *Client) CreateDefaultTemplate(d *ForemanDefaultTemplate) (*ForemanDefau
 
 	// All parameters are send individually. Yeay for that
 	var createdDefaultTemplate ForemanDefaultTemplate
-	parameterJSONBytes, jsonEncErr := c.WrapJSONWithTaxonomy("os_default_template", d)
+	wrapped, _ := c.wrapParameters("os_default_template", d)
+	parameterJSONBytes, jsonEncErr := json.Marshal(wrapped)
 	if jsonEncErr != nil {
 		return nil, jsonEncErr
 	}
@@ -101,7 +102,9 @@ func (c *Client) UpdateDefaultTemplate(d *ForemanDefaultTemplate, id int) (*Fore
 	log.Tracef("foreman/api/parameter.go#Update")
 
 	reqEndpoint := fmt.Sprintf(DefaultTemplateEndpointPrefix+"/%d", d.OperatingSystemId, id)
-	parameterJSONBytes, jsonEncErr := c.WrapJSONWithTaxonomy("os_default_template", d)
+	wrapped, _ := c.wrapParameters("os_default_template", d)
+	parameterJSONBytes, jsonEncErr := json.Marshal(wrapped)
+
 	if jsonEncErr != nil {
 		return nil, jsonEncErr
 	}

--- a/foreman/resource_foreman_hostgroup.go
+++ b/foreman/resource_foreman_hostgroup.go
@@ -60,7 +60,7 @@ func resourceForemanHostgroup() *schema.Resource {
 
 			"root_password": &schema.Schema{
 				Type:         schema.TypeString,
-				Required:     true,
+				Optional:     true,
 				Sensitive:    true,
 				ValidateFunc: validation.StringLenBetween(8, 256),
 				Description:  "Default root password",
@@ -169,7 +169,6 @@ func resourceForemanHostgroup() *schema.Resource {
 			"puppet_ca_proxy_id": &schema.Schema{
 				Type:         schema.TypeInt,
 				Optional:     true,
-				Default:      1,
 				ValidateFunc: validation.IntAtLeast(0),
 				Description: "ID of the smart proxy acting as the puppet certificate " +
 					"authority server for this hostgroup.",
@@ -178,7 +177,6 @@ func resourceForemanHostgroup() *schema.Resource {
 			"puppet_proxy_id": &schema.Schema{
 				Type:         schema.TypeInt,
 				Optional:     true,
-				Default:      1,
 				ValidateFunc: validation.IntAtLeast(0),
 				Description: "ID of the smart proxy acting as the puppet proxy " +
 					"server for this hostgroup.",


### PR DESCRIPTION
Remove custom json wrapper function for os default template
- gives a 500 error on applying because additional parameters added by wrapper

Remove default values on options in host groups which are allowed to be null
- Host groups can't be added when specific puppetproxy's are not present

Remove requirement for setting root password
- allow to be null according to api (https://apidocs.theforeman.org/foreman/2.0/apidoc/v2/hostgroups/update.html)