### PR TITLE
Add Katello params to hostgroup

### DIFF
--- a/foreman/api/hostgroup.go
+++ b/foreman/api/hostgroup.go
@@ -64,6 +64,12 @@ type ForemanHostgroup struct {
 	SubnetId int `json:"subnet_id,omitempty"`
 	// Default PXELoader for the hostgroup
 	PXELoader string `json:"pxe_loader,omitempty"`
+	// ID of the Katello Lifecycle Environment
+	LifecycleId int `json:"lifecycle_environment_id,omitempty"`
+	// ID of the Katello content view
+	ContentViewId int `json:"content_view_id,omitempty"`
+	// ID of Smart Proxy serving the content
+	ContentSourceId int `json:"content_source_id,omitempty"`
 
 	// Map of HostGroupParameters
 	HostGroupParameters []ForemanKVParameter `json:"group_parameters_attributes,omitempty"`
@@ -84,8 +90,11 @@ func (fh ForemanHostgroup) MarshalJSON() ([]byte, error) {
 
 	fhMap["architecture_id"] = intIdToJSONString(fh.ArchitectureId)
 	fhMap["compute_profile_id"] = intIdToJSONString(fh.ComputeProfileId)
+	fhMap["content_source_id"] = intIdToJSONString(fh.ContentSourceId)
+	fhMap["content_view_id"] = intIdToJSONString(fh.ContentViewId)
 	fhMap["domain_id"] = intIdToJSONString(fh.DomainId)
 	fhMap["environment_id"] = intIdToJSONString(fh.EnvironmentId)
+	fhMap["lifecycle_environment_id"] = intIdToJSONString(fh.LifecycleId)
 	fhMap["medium_id"] = intIdToJSONString(fh.MediumId)
 	fhMap["operatingsystem_id"] = intIdToJSONString(fh.OperatingSystemId)
 	fhMap["parent_id"] = intIdToJSONString(fh.ParentId)
@@ -135,8 +144,11 @@ func (fh *ForemanHostgroup) UnmarshalJSON(b []byte) error {
 	// Unmarshal the remaining foreign keys to their id
 	fh.ArchitectureId = unmarshalInteger(fhMap["architecture_id"])
 	fh.ComputeProfileId = unmarshalInteger(fhMap["compute_profile_id"])
+	fh.ContentSourceId = unmarshalInteger(fhMap["content_source_id"])
+	fh.ContentViewId = unmarshalInteger(fhMap["content_view_id"])
 	fh.DomainId = unmarshalInteger(fhMap["domain_id"])
 	fh.EnvironmentId = unmarshalInteger(fhMap["environment_id"])
+	fh.LifecycleId = unmarshalInteger(fhMap["lifecycle_environment_id"])
 	fh.MediumId = unmarshalInteger(fhMap["medium_id"])
 	fh.OperatingSystemId = unmarshalInteger(fhMap["operatingsystem_id"])
 	fh.ParentId = unmarshalInteger(fhMap["parent_id"])

--- a/foreman/resource_foreman_hostgroup.go
+++ b/foreman/resource_foreman_hostgroup.go
@@ -119,6 +119,22 @@ func resourceForemanHostgroup() *schema.Resource {
 				Description:  "ID of the compute profile associated with this hostgroup.",
 			},
 
+			"content_source_id": &schema.Schema{
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.IntAtLeast(0),
+				Description:  "ID of the content source associated with this hostgroup.",
+			},
+
+			"content_view_id": &schema.Schema{
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.IntAtLeast(0),
+				Description:  "ID of the content view associated with this hostgroup.",
+			},
+
 			"domain_id": &schema.Schema{
 				Type:         schema.TypeInt,
 				Optional:     true,
@@ -133,6 +149,14 @@ func resourceForemanHostgroup() *schema.Resource {
 				Computed:     true,
 				ValidateFunc: validation.IntAtLeast(0),
 				Description:  "ID of the environment associated with this hostgroup.",
+			},
+
+			"lifecycle_environment_id": &schema.Schema{
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.IntAtLeast(0),
+				Description:  "ID of the lifecycle environment associated with this hostgroup.",
 			},
 
 			"medium_id": &schema.Schema{
@@ -240,12 +264,24 @@ func buildForemanHostgroup(d *schema.ResourceData) *api.ForemanHostgroup {
 		hostgroup.ComputeProfileId = attr.(int)
 	}
 
+	if attr, ok = d.GetOk("content_source_id"); ok {
+		hostgroup.ContentSourceId = attr.(int)
+	}
+
+	if attr, ok = d.GetOk("content_view_id"); ok {
+		hostgroup.ContentViewId = attr.(int)
+	}
+
 	if attr, ok = d.GetOk("domain_id"); ok {
 		hostgroup.DomainId = attr.(int)
 	}
 
 	if attr, ok = d.GetOk("environment_id"); ok {
 		hostgroup.EnvironmentId = attr.(int)
+	}
+
+	if attr, ok = d.GetOk("lifecycle_environment_id"); ok {
+		hostgroup.LifecycleId = attr.(int)
 	}
 
 	if attr, ok = d.GetOk("medium_id"); ok {
@@ -304,8 +340,11 @@ func setResourceDataFromForemanHostgroup(d *schema.ResourceData, fh *api.Foreman
 	d.Set("parameters", fh.HostGroupParameters)
 	d.Set("architecture_id", fh.ArchitectureId)
 	d.Set("compute_profile_id", fh.ComputeProfileId)
+	d.Set("content_source_id", fh.ContentSourceId)
+	d.Set("content_view_id", fh.ContentViewId)
 	d.Set("domain_id", fh.DomainId)
 	d.Set("environment_id", fh.EnvironmentId)
+	d.Set("lifecycle_environment_id", fh.LifecycleId)
 	d.Set("medium_id", fh.MediumId)
 	d.Set("operatingsystem_id", fh.OperatingSystemId)
 	d.Set("parent_id", fh.ParentId)


### PR DESCRIPTION
Adds lifecycle_environment_id, content_source_id & content_view_id parameters to the foreman_hostgroup resource.