### PR TITLE
Refactor host and add managed fields

### DIFF
--- a/docs/resources/foreman_host.md
+++ b/docs/resources/foreman_host.md
@@ -31,6 +31,7 @@ The following arguments are supported:
 - `image_id` - (Optional, Force New) ID of an image to be used as base for this host when cloning
 - `interfaces_attributes` - (Optional) Host interface information.
 - `manage_build` - (Optional) Create host only, don't set build status or manage power states
+- `managed` - (Optional) Whether or not this host is managed by Foreman.
 - `medium_id` - (Optional, Force New) ID of the medium mounted on the host.
 - `method` - (Optional, Force New) Chooses a method with which to provision the HostOptions are "build" and "image"
 - `model_id` - (Optional) ID of the hardware model if applicable
@@ -59,6 +60,7 @@ The following attributes are exported:
 - `image_id` - ID of an image to be used as base for this host when cloning
 - `interfaces_attributes` - Host interface information.
 - `manage_build` - Create host only, don't set build status or manage power states
+- `managed` - Whether or not this host is managed by Foreman.
 - `medium_id` - ID of the medium mounted on the host.
 - `method` - Chooses a method with which to provision the HostOptions are "build" and "image"
 - `model_id` - ID of the hardware model if applicable

--- a/docs/resources/foreman_host.md
+++ b/docs/resources/foreman_host.md
@@ -30,8 +30,8 @@ The following arguments are supported:
 - `hostgroup_id` - (Optional, Force New) ID of the hostgroup to assign to the host.
 - `image_id` - (Optional, Force New) ID of an image to be used as base for this host when cloning
 - `interfaces_attributes` - (Optional) Host interface information.
-- `manage_build` - (Optional) Create host only, don't set build status or manage power states
-- `managed` - (Optional) Whether or not this host is managed by Foreman.
+- `manage_build` - (Optional) REMOVED, please use the new 'managed' key instead. Create host only, don't set build status or manage power states
+- `managed` - (Optional) Whether or not this host is managed by Foreman. Create host only, don't set build status or manage power states.
 - `medium_id` - (Optional, Force New) ID of the medium mounted on the host.
 - `method` - (Optional, Force New) Chooses a method with which to provision the HostOptions are "build" and "image"
 - `model_id` - (Optional) ID of the hardware model if applicable
@@ -59,8 +59,8 @@ The following attributes are exported:
 - `hostgroup_id` - ID of the hostgroup to assign to the host.
 - `image_id` - ID of an image to be used as base for this host when cloning
 - `interfaces_attributes` - Host interface information.
-- `manage_build` - Create host only, don't set build status or manage power states
-- `managed` - Whether or not this host is managed by Foreman.
+- `manage_build` - REMOVED, please use the new 'managed' key instead. Create host only, don't set build status or manage power states
+- `managed` - Whether or not this host is managed by Foreman. Create host only, don't set build status or manage power states.
 - `medium_id` - ID of the medium mounted on the host.
 - `method` - Chooses a method with which to provision the HostOptions are "build" and "image"
 - `model_id` - ID of the hardware model if applicable

--- a/foreman/api/host.go
+++ b/foreman/api/host.go
@@ -76,6 +76,8 @@ type ForemanHost struct {
 	EnableBMC bool
 	// Boolean to track success of BMC Calls
 	BMCSuccess bool
+	// Whether or not the host is managed by foreman
+	Managed bool `json:"managed"`
 	// Additional information about this host
 	Comment string `json:"comment"`
 	// Nested struct defining any interfaces associated with the Host

--- a/foreman/api/host.go
+++ b/foreman/api/host.go
@@ -130,10 +130,11 @@ type ForemanInterfacesAttribute struct {
 	Destroy bool `json:"_destroy,omitempty"`
 }
 
-// foremanHostJSON struct used for JSON decode.
-type foremanHostJSON struct {
-	InterfacesAttributes []ForemanInterfacesAttribute `json:"interfaces"`
-	PuppetClasses        []ForemanObject              `json:"puppetclasses"`
+// foremanHostDecode struct used for JSON decode.
+type foremanHostDecode struct {
+	ForemanHost
+	InterfacesAttributesDecode []ForemanInterfacesAttribute `json:"interfaces"`
+	PuppetClassesDecode        []ForemanObject              `json:"puppetclasses"`
 }
 
 // Power struct for marshal/unmarshal of power state
@@ -294,7 +295,7 @@ func (c *Client) ReadHost(id int) (*ForemanHost, error) {
 		return nil, reqErr
 	}
 
-	var readHost ForemanHost
+	var readHost foremanHostDecode
 	sendErr := c.SendAndParse(req, &readHost)
 	if sendErr != nil {
 		return nil, sendErr
@@ -304,8 +305,10 @@ func (c *Client) ReadHost(id int) (*ForemanHost, error) {
 	if len(computeAttributes) > 0 {
 		readHost.ComputeAttributes = computeAttributes
 	}
+	readHost.InterfacesAttributes = readHost.InterfacesAttributesDecode
+	readHost.PuppetClassIds = foremanObjectArrayToIdIntArray(readHost.PuppetClassesDecode)
 
-	return &readHost, nil
+	return &readHost.ForemanHost, nil
 }
 
 // UpdateHost updates a ForemanHost's attributes.  The host with the ID of the

--- a/foreman/resource_foreman_host.go
+++ b/foreman/resource_foreman_host.go
@@ -95,6 +95,13 @@ func resourceForemanHost() *schema.Resource {
 					"boot to PXE and power on. Defaults to `false`.",
 			},
 
+			"managed": &schema.Schema{
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "Whether or not this host is managed by Foreman.",
+			},
+
 			"manage_build": &schema.Schema{
 				Type:        schema.TypeBool,
 				Optional:    true,
@@ -398,6 +405,7 @@ func buildForemanHost(d *schema.ResourceData) *api.ForemanHost {
 	host.OwnerType = d.Get("owner_type").(string)
 	host.Method = d.Get("method").(string)
 	host.OwnerId = d.Get("owner_id").(int)
+	host.Managed = d.Get("managed").(bool)
 
 	if attr, ok = d.GetOk("domain_id"); ok {
 		host.DomainId = attr.(int)

--- a/foreman/resource_foreman_host.go
+++ b/foreman/resource_foreman_host.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/HanseMerkur/terraform-provider-foreman/foreman/api"
@@ -52,6 +53,13 @@ func resourceForemanHost() *schema.Resource {
 						"%s \"compute01.dc1.company.com\"",
 					autodoc.MetaExample,
 				),
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					domainName := d.Get("domain_name").(string)
+					if domainName == "" || !(strings.Contains(new, domainName) || strings.Contains(old, domainName)) {
+						return false
+					}
+					return strings.Replace(old, "."+domainName, "", 1) == strings.Replace(new, "."+domainName, "", 1)
+				},
 			},
 
 			// -- Optional --

--- a/foreman/resource_foreman_host_test.go
+++ b/foreman/resource_foreman_host_test.go
@@ -30,14 +30,28 @@ func ForemanHostToInstanceState(obj api.ForemanHost) *terraform.InstanceState {
 	// Build the attribute map from ForemanHost
 	attr := map[string]string{}
 	attr["name"] = obj.Name
-	attr["domain_id"] = strconv.Itoa(obj.DomainId)
+	if obj.DomainId != nil {
+		attr["domain_id"] = strconv.Itoa(*obj.DomainId)
+	}
 	attr["domain_name"] = obj.DomainName
-	attr["environment_id"] = strconv.Itoa(obj.EnvironmentId)
-	attr["hostgroup_id"] = strconv.Itoa(obj.HostgroupId)
-	attr["operatingsystem_id"] = strconv.Itoa(obj.OperatingSystemId)
-	attr["medium_id"] = strconv.Itoa(obj.MediumId)
-	attr["image_id"] = strconv.Itoa(obj.ImageId)
-	attr["owner_id"] = strconv.Itoa(obj.OwnerId)
+	if obj.EnvironmentId != nil {
+		attr["environment_id"] = strconv.Itoa(*obj.EnvironmentId)
+	}
+	if obj.HostgroupId != nil {
+		attr["hostgroup_id"] = strconv.Itoa(*obj.HostgroupId)
+	}
+	if obj.OperatingSystemId != nil {
+		attr["operatingsystem_id"] = strconv.Itoa(*obj.OperatingSystemId)
+	}
+	if obj.MediumId != nil {
+		attr["medium_id"] = strconv.Itoa(*obj.MediumId)
+	}
+	if obj.ImageId != nil {
+		attr["image_id"] = strconv.Itoa(*obj.ImageId)
+	}
+	if obj.OwnerId != nil {
+		attr["owner_id"] = strconv.Itoa(*obj.OwnerId)
+	}
 	attr["owner_type"] = obj.OwnerType
 	attr["bmc_success"] = strconv.FormatBool(obj.BMCSuccess)
 	attr["interfaces_attributes.#"] = strconv.Itoa(len(obj.InterfacesAttributes))
@@ -95,13 +109,22 @@ func RandForemanHost() api.ForemanHost {
 	obj.ForemanObject = fo
 
 	obj.Build = rand.Intn(2) > 0
-	obj.OperatingSystemId = rand.Intn(100)
-	obj.DomainId = rand.Intn(100)
-	obj.HostgroupId = rand.Intn(100)
-	obj.EnvironmentId = rand.Intn(100)
-	obj.MediumId = rand.Intn(100)
-	obj.ImageId = rand.Intn(100)
-	obj.OwnerId = rand.Intn(100)
+
+	operatingSystemId := rand.Intn(100)
+	domainId := rand.Intn(100)
+	hostgroupId := rand.Intn(100)
+	environmentId := rand.Intn(100)
+	mediumId := rand.Intn(100)
+	imageId := rand.Intn(100)
+	ownerId := rand.Intn(100)
+
+	obj.OperatingSystemId = &operatingSystemId
+	obj.DomainId = &domainId
+	obj.HostgroupId = &hostgroupId
+	obj.EnvironmentId = &environmentId
+	obj.MediumId = &mediumId
+	obj.ImageId = &imageId
+	obj.OwnerId = &ownerId
 	obj.OwnerType = "Usergroup"
 
 	hostCompAttr := make(map[string]interface{})


### PR DESCRIPTION
The first commit add a `managed` field to host. This allow to not specify the mac address/ip address if you set it to false (not sure if this is redundant to manage_build, I think it should be ok like that though).

The second commit refactor a bit the ForemanHost mainly adding a bunch of omitempty (and having *int instead of int so that omitempty actually works), removing the custom marshaling and making `ComputeAttributes` type a little more precise (from interface{} to map[string]interface{}). I also removed all the `GetOk` call while building the ForemanHost struct as if the schema attribute is `computed` this method always return ~~true~~ false (https://github.com/hashicorp/terraform-plugin-sdk/blob/9bdb216a4ab835003a624b0a15ac39c58ef2861e/helper/schema/resource_diff.go#L386).