### PR TITLE
host: remove bmc_success

### DIFF
--- a/docs/resources/foreman_host.md
+++ b/docs/resources/foreman_host.md
@@ -19,7 +19,7 @@ resource "foreman_host" "example" {
 
 The following arguments are supported:
 
-- `bmc_success` - (Optional) Tracks the partial state of BMC operations on host creation. If these operations fail, the host will be created in Foreman and this boolean will remain `false`. On the next `terraform apply` will trigger the host update to pick back up with the BMC operations.
+- `bmc_success` - (Optional) REMOVED - Tracks the partial state of BMC operations on host creation. If these operations fail, the host will be created in Foreman and this boolean will remain `false`. On the next `terraform apply` will trigger the host update to pick back up with the BMC operations.
 - `comment` - (Optional) Add additional information about this host.Note: Changes to this attribute will trigger a host rebuild.
 - `compute_attributes` - (Optional) Hypervisor specific VM options. Must be a JSON string, as every compute provider has different attributes schema
 - `compute_profile_id` - (Optional) 

--- a/foreman/resource_foreman_host_test.go
+++ b/foreman/resource_foreman_host_test.go
@@ -53,7 +53,6 @@ func ForemanHostToInstanceState(obj api.ForemanHost) *terraform.InstanceState {
 		attr["owner_id"] = strconv.Itoa(*obj.OwnerId)
 	}
 	attr["owner_type"] = obj.OwnerType
-	attr["bmc_success"] = strconv.FormatBool(obj.BMCSuccess)
 	attr["interfaces_attributes.#"] = strconv.Itoa(len(obj.InterfacesAttributes))
 	attr["retry_count"] = "1"
 	compute_attributes, _ := json.Marshal(obj.ComputeAttributes)
@@ -176,7 +175,7 @@ func ForemanHostResourceDataCompare(t *testing.T, r1 *schema.ResourceData, r2 *s
 	r := resourceForemanHost()
 	for key, value := range r.Schema {
 		// Skip compute_attribs as it gets nulled
-		if key == "compute_attributes" || key == "bmc_success" {
+		if key == "compute_attributes" {
 			continue
 		}
 		m[key] = value.Type


### PR DESCRIPTION
This feature didn't work as bmc_success is never set to false
anywhere in the code. As this feature may not make sense in the first
place and doesn't work anyway, this commit removes it.

Signed-off-by: Arthur Outhenin-Chalandre <arthur.outhenin-chalandre@cern.ch>