### PR TITLE
host: improving managed documentation

### DIFF
--- a/docs/resources/foreman_host.md
+++ b/docs/resources/foreman_host.md
@@ -31,7 +31,7 @@ The following arguments are supported:
 - `image_id` - (Optional, Force New) ID of an image to be used as base for this host when cloning
 - `interfaces_attributes` - (Optional) Host interface information.
 - `manage_build` - (Optional) REMOVED, please use the new 'managed' key instead. Create host only, don't set build status or manage power states
-- `managed` - (Optional) Whether or not this host is managed by Foreman. Create host only, don't set build status or manage power states.
+- `managed` - (Optional) Whether or not this host is managed by Foreman. Enabling this (enabled by default) also power on the host on creation.
 - `medium_id` - (Optional, Force New) ID of the medium mounted on the host.
 - `method` - (Optional, Force New) Chooses a method with which to provision the HostOptions are "build" and "image"
 - `model_id` - (Optional) ID of the hardware model if applicable
@@ -60,7 +60,7 @@ The following attributes are exported:
 - `image_id` - ID of an image to be used as base for this host when cloning
 - `interfaces_attributes` - Host interface information.
 - `manage_build` - REMOVED, please use the new 'managed' key instead. Create host only, don't set build status or manage power states
-- `managed` - Whether or not this host is managed by Foreman. Create host only, don't set build status or manage power states.
+- `managed` - Whether or not this host is managed by Foreman. Enabling this (enabled by default) also power on the host on creation.
 - `medium_id` - ID of the medium mounted on the host.
 - `method` - Chooses a method with which to provision the HostOptions are "build" and "image"
 - `model_id` - ID of the hardware model if applicable

--- a/foreman/resource_foreman_host.go
+++ b/foreman/resource_foreman_host.go
@@ -119,7 +119,8 @@ func resourceForemanHost() *schema.Resource {
 				Optional: true,
 				Default:  true,
 				Description: "Whether or not this host is managed by Foreman." +
-					" Create host only, don't set build status or manage power states.",
+					" Enabling this (enabled by default) also power on" +
+					" the host on creation.",
 			},
 
 			"retry_count": &schema.Schema{


### PR DESCRIPTION
Signed-off-by: Arthur Outhenin-Chalandre <arthur.outhenin-chalandre@cern.ch>

Improving the documentation following the comment on #60 for managed key, it no longer mentions setting the build status as I think it is just confusing and make sens for a foreman admin anyway.