### PR TITLE
Add bmc_id to subnet resource

### DIFF
--- a/docs/data-sources/foreman_subnet.md
+++ b/docs/data-sources/foreman_subnet.md
@@ -28,6 +28,7 @@ The following arguments are supported:
 
 The following attributes are exported:
 
+- `bmc_id` - BMC Proxy ID to use within this subnet
 - `boot_mode` - Default boot mode for instances assigned to this subnet. Values include: `"Static"`, `"DHCP"`.
 - `dhcp_id` - DHCP Proxy ID to use within this subnet
 - `dns_primary` - Primary DNS server for this subnet.

--- a/docs/resources/foreman_subnet.md
+++ b/docs/resources/foreman_subnet.md
@@ -21,6 +21,7 @@ resource "foreman_subnet" "example" {
 
 The following arguments are supported:
 
+- `bmc_id` - (Optional) BMC Proxy ID to use within this subnet
 - `boot_mode` - (Optional) Default boot mode for instances assigned to this subnet. Values include: `"Static"`, `"DHCP"`.
 - `dhcp_id` - (Optional) DHCP Proxy ID to use within this subnet
 - `dns_primary` - (Optional) Primary DNS server for this subnet.
@@ -46,6 +47,7 @@ The following arguments are supported:
 
 The following attributes are exported:
 
+- `bmc_id` - BMC Proxy ID to use within this subnet
 - `boot_mode` - Default boot mode for instances assigned to this subnet. Values include: `"Static"`, `"DHCP"`.
 - `dhcp_id` - DHCP Proxy ID to use within this subnet
 - `dns_primary` - Primary DNS server for this subnet.

--- a/foreman/api/subnet.go
+++ b/foreman/api/subnet.go
@@ -62,7 +62,7 @@ type ForemanSubnet struct {
 	// DHCP ID
 	DhcpID int `json:"dhcp_id,omitempty"`
 	// BMC ID
-	BmcID int `json:"bmc_id,omitempty"`
+	BmcID *int `json:"bmc_id,omitempty"`
 	// TFTP ID
 	TftpID int `json:"tftp_id,omitempty"`
 	// HTTP Boot ID

--- a/foreman/api/subnet.go
+++ b/foreman/api/subnet.go
@@ -61,6 +61,8 @@ type ForemanSubnet struct {
 	TemplateID int `json:"template_id,omitempty"`
 	// DHCP ID
 	DhcpID int `json:"dhcp_id,omitempty"`
+	// BMC ID
+	BmcID int `json:"bmc_id,omitempty"`
 	// TFTP ID
 	TftpID int `json:"tftp_id,omitempty"`
 	// HTTP Boot ID

--- a/foreman/resource_foreman_subnet.go
+++ b/foreman/resource_foreman_subnet.go
@@ -154,6 +154,11 @@ func resourceForemanSubnet() *schema.Resource {
 				Optional:    true,
 				Description: "DHCP Proxy ID to use within this subnet",
 			},
+			"bmc_id": &schema.Schema{
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "BMC Proxy ID to use within this subnet",
+			},
 			"tftp_id": &schema.Schema{
 				Type:        schema.TypeInt,
 				Optional:    true,
@@ -243,6 +248,9 @@ func buildForemanSubnet(d *schema.ResourceData) *api.ForemanSubnet {
 	if attr, ok = d.GetOk("dhcp_id"); ok {
 		s.DhcpID = attr.(int)
 	}
+	if attr, ok = d.GetOk("bmc_id"); ok {
+		s.BmcID = attr.(int)
+	}
 	if attr, ok = d.GetOk("tftp_id"); ok {
 		s.TftpID = attr.(int)
 	}
@@ -280,6 +288,7 @@ func setResourceDataFromForemanSubnet(d *schema.ResourceData, fs *api.ForemanSub
 	d.Set("mtu", fs.Mtu)
 	d.Set("template_id", fs.TemplateID)
 	d.Set("dhcp_id", fs.DhcpID)
+	d.Set("bmc_id", fs.BmcID)
 	d.Set("tftp_id", fs.TftpID)
 	d.Set("httpboot_id", fs.HTTPBootID)
 	d.Set("domain_ids", fs.DomainIDs)

--- a/foreman/resource_foreman_subnet.go
+++ b/foreman/resource_foreman_subnet.go
@@ -248,8 +248,9 @@ func buildForemanSubnet(d *schema.ResourceData) *api.ForemanSubnet {
 	if attr, ok = d.GetOk("dhcp_id"); ok {
 		s.DhcpID = attr.(int)
 	}
-	if attr, ok = d.GetOk("bmc_id"); ok {
-		s.BmcID = attr.(int)
+	bmcId := d.Get("bmc_id").(int)
+	if bmcId != 0 {
+		s.BmcID = &bmcId
 	}
 	if attr, ok = d.GetOk("tftp_id"); ok {
 		s.TftpID = attr.(int)


### PR DESCRIPTION
Fixes issue #59. Allows BMC Proxy to be specified on subnets' Proxies tab:
![image](https://user-images.githubusercontent.com/5072156/167358068-0872f4d6-088a-4293-9e8e-6b956c48f90c.png)