### PR TITLE
host: mark interface_attributes as optional

### DIFF
--- a/foreman/resource_foreman_host.go
+++ b/foreman/resource_foreman_host.go
@@ -272,6 +272,7 @@ func resourceForemanHost() *schema.Resource {
 			"interfaces_attributes": &schema.Schema{
 				Type:        schema.TypeList,
 				Optional:    true,
+				Computed:    true,
 				Elem:        resourceForemanInterfacesAttributes(),
 				Description: "Host interface information.",
 			},


### PR DESCRIPTION
This field can be updated outside of terraform at runtime (i.e.: by
puppet)

Signed-off-by: Arthur Outhenin-Chalandre <arthur.outhenin-chalandre@cern.ch>