### PR TITLE
client: fix foreman parameters conversion

### DIFF
--- a/foreman/api/client.go
+++ b/foreman/api/client.go
@@ -90,8 +90,6 @@ func FromKV(kv []ForemanKVParameter) (ret map[string]string) {
 }
 
 func ToKV(m map[string]interface{}) (ret []ForemanKVParameter) {
-	ret = make([]ForemanKVParameter, len(m))
-
 	for key, value := range m {
 		ret = append(ret, ForemanKVParameter{
 			Name:  key,


### PR DESCRIPTION
make() was allocating empty parameters and then we were adding the real
entries after those empty one. In this commit we simply remove make and
construct the slice dynamically with append.

Signed-off-by: Arthur Outhenin-Chalandre <arthur.outhenin-chalandre@cern.ch>

Fixes #76 